### PR TITLE
Update GitHub workflow to attach binaries to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Build binary
         run: bun build ./src/index.ts --compile --outfile app${{ matrix.binary_ext }}
 
-      - name: Upload binary
-        uses: actions/upload-artifact@v4
+      - name: Attach binary to release
+        uses: softprops/action-gh-release@v1
         with:
-          name: app-${{ matrix.os }}
-          path: app${{ matrix.binary_ext }}
+          files: app${{ matrix.binary_ext }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace upload-artifact with action-gh-release to automatically attach compiled binaries to GitHub releases instead of storing as artifacts.

Fixes #3