### PR TITLE
fix: remove log line from setupEventWatchers

### DIFF
--- a/src/logs.ts
+++ b/src/logs.ts
@@ -66,7 +66,6 @@ export async function setupEventWatchers(contractAddresses: string[], abis: AbiE
     )
     return unwatchFunctions
   } catch (error) {
-    logger.logPhase('Real-time Event Monitoring', 'error')
     logger.error(
       `Failed to set up event subscriptions: ${error instanceof Error ? error.message : 'Unknown error'}`
     )


### PR DESCRIPTION
Fixes #10

Removed the redundant logger.logPhase error log from the setupEventWatchers function catch block as requested.

Generated with [Claude Code](https://claude.ai/code)