### PR TITLE
feat: remove unused hardcoded base block constants

### DIFF
--- a/src/utils/seeder.ts
+++ b/src/utils/seeder.ts
@@ -1,10 +1,5 @@
 import { logger } from './logger'
 
-// Base block defaults for different networks
-const baseBlockMainnet = 17000000n
-const baseBlockHolesky = 1159609n
-const baseBlockSepolia = 8080000n
-
 /**
  * Helper function to loop through blocks in batches with enhanced progress tracking
  */


### PR DESCRIPTION
Removes unused hardcoded base block constants from seeder.ts to make base blocks fully configurable.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)